### PR TITLE
Restrict to use Texy without namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"nette/di": "~2.2",
 		"nette/caching": "~2.2",
 		"nette/utils": "~2.2",
-		"texy/texy": "~2.6"
+		"texy/texy": "~2.6 <2.8"
 	},
 	"require-dev": {
 		"nette/tester": "~1.2.0"


### PR DESCRIPTION
Temporary fix
